### PR TITLE
fix: CI support multiple rust toolchians

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
           override: true
 
@@ -52,12 +52,14 @@ jobs:
           args: --no-default-features --features runtime-async-std
 
       - name: Cargo Clippy
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'nightly'
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
 
       - name: Cargo Fmt Check
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'nightly'
         uses: actions-rs/cargo@v1
         with:
           command: fmt


### PR DESCRIPTION
For now, CI only use stable toolchain:
https://github.com/casbin-rs/actix-casbin-auth/blob/05a4a269d60494fdeaf26562e8a4d5db9a695b7c/.github/workflows/ci.yml#L28
For example, in Auto Build CI (ubuntu-latest, nightly), stable toolchain is installed instead of nightly:
https://github.com/casbin-rs/actix-casbin-auth/runs/5624601470?check_suite_focus=true#step:3:41
![image](https://user-images.githubusercontent.com/40566803/166632182-bda366d7-2ac9-4ac3-b7fc-e6b1e54a197f.png)

I fixed this issues by replacing `toolchain: stable` with `toolchain: ${{ matrix.rust }}`, now it works fine:
https://github.com/greenhandatsjtu/actix-casbin-auth/runs/6284623554?check_suite_focus=true#step:3:49
![image](https://user-images.githubusercontent.com/40566803/166632401-b7112e52-07c4-43b5-a6ad-c451ab58468a.png)
