### PR TITLE
fix: corrected the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ async fn main() -> Result<()> {
 }
 ```
 
-
 ## License
 
 This project is licensed under

--- a/README.md
+++ b/README.md
@@ -43,11 +43,10 @@ pub struct FakeAuth;
 
 impl<S: 'static, B> Transform<S> for FakeAuth
     where
-        S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+        S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
         S::Future: 'static,
         B: 'static,
 {
-    type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
     type Error = Error;
     type InitError = ();
@@ -67,11 +66,10 @@ pub struct FakeAuthMiddleware<S> {
 
 impl<S, B> Service for FakeAuthMiddleware<S>
     where
-        S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+        S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
         S::Future: 'static,
         B: 'static,
 {
-    type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
     type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ async fn main() -> Result<()> {
 }
 ```
 
+
 ## License
 
 This project is licensed under


### PR DESCRIPTION
On explicitly mentioning the `Request = ServiceRequest`, the following error was encountered in the Casbin-rs/examples repository
![Screen Shot 2022-06-30 at 11 37 13 PM](https://user-images.githubusercontent.com/85673539/176839262-048cb284-7833-493c-8571-5c20d9ecbb4e.png)

Hence updated the Readme file to resolve the error.

Reference: [auth.rs](https://github.com/casbin-rs/examples/blob/master/actix-middleware-example/src/middleware/authn.rs#L29)