### PR TITLE
Bump casbin to version 2.2.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "actix_casbin_auth"
 path = "src/lib.rs"
 
 [dependencies]
-casbin = { version = "2.0.9", default-features = false, features = ["incremental", "cached"] }
+casbin = { version = "2.2.0", default-features = false, features = ["incremental", "cached"] }
 tokio = { version = "1.17.0", default-features = false, optional = true }
 async-std = { version = "1.10.0", default-features = false, optional = true }
 actix-web = { version = "4.0.1", default-features = false }


### PR DESCRIPTION
Closes: #41 